### PR TITLE
3つのバグ修正と1つの改善

### DIFF
--- a/OptimizeEditBox/OptimizeEditBox.cpp
+++ b/OptimizeEditBox/OptimizeEditBox.cpp
@@ -67,13 +67,13 @@ BOOL COptimizeEditBoxApp::initHook()
 	if (m_selectionEdgeColor != CLR_NONE) writeAbsoluteAddress(exedit_auf + 0x00038076, &m_selectionEdgeColor);
 	if (m_selectionBkColor != CLR_NONE) writeAbsoluteAddress(exedit_auf + 0x00038087, &m_selectionBkColor);
 
-	if (m_addTextEditBoxHeight)
+	if (m_addTextEditBoxHeight || m_font != nullptr)
 	{
 		hookAbsoluteCall(exedit_auf + 0x0008C46E, Exedit_CreateTextEditBox);
 		addInt32(exedit_auf + 0x0008CC56 + 1, m_addTextEditBoxHeight);
 	}
 
-	if (m_addScriptEditBoxHeight)
+	if (m_addScriptEditBoxHeight != 0 || m_font != nullptr)
 	{
 		hookAbsoluteCall(exedit_auf + 0x00087658, Exedit_CreateScriptEditBox);
 		addInt32(exedit_auf + 0x000876DE + 1, m_addScriptEditBoxHeight);

--- a/OptimizeEditBox/OptimizeEditBox.cpp
+++ b/OptimizeEditBox/OptimizeEditBox.cpp
@@ -67,7 +67,7 @@ BOOL COptimizeEditBoxApp::initHook()
 	if (m_selectionEdgeColor != CLR_NONE) writeAbsoluteAddress(exedit_auf + 0x00038076, &m_selectionEdgeColor);
 	if (m_selectionBkColor != CLR_NONE) writeAbsoluteAddress(exedit_auf + 0x00038087, &m_selectionBkColor);
 
-	if (m_addTextEditBoxHeight || m_font != nullptr)
+	if (m_addTextEditBoxHeight != 0 || m_font != nullptr)
 	{
 		hookAbsoluteCall(exedit_auf + 0x0008C46E, Exedit_CreateTextEditBox);
 		addInt32(exedit_auf + 0x0008CC56 + 1, m_addTextEditBoxHeight);

--- a/OptimizeEditBox/OptimizeEditBox.cpp
+++ b/OptimizeEditBox/OptimizeEditBox.cpp
@@ -84,7 +84,9 @@ BOOL COptimizeEditBoxApp::initHook()
 
 	if (m_usesUnicodeInput)
 	{
+		if (m_usesCtrlA) hook_GetMessageA = hook_ctrlA_GetMessageA;
 		ATTACH_HOOK_PROC(GetMessageA);
+		ATTACH_HOOK_PROC(DispatchMessageA);
 //		ATTACH_HOOK_PROC(PeekMessageA);
 	}
 
@@ -117,6 +119,7 @@ BOOL COptimizeEditBoxApp::termHook()
 	if (m_usesUnicodeInput)
 	{
 		DETACH_HOOK_PROC(GetMessageA);
+		DETACH_HOOK_PROC(DispatchMessageA);
 //		DETACH_HOOK_PROC(PeekMessageA);
 	}
 

--- a/OptimizeEditBox/OptimizeEditBox.vcxproj
+++ b/OptimizeEditBox/OptimizeEditBox.vcxproj
@@ -190,6 +190,7 @@
     <ClInclude Include="..\AviUtl\aulslib\memref.h" />
     <ClInclude Include="..\AviUtl\aulslib\memref2.h" />
     <ClInclude Include="..\Common\MyTracer.h" />
+    <ClInclude Include="edit_predicates.h" />
     <ClInclude Include="OptimizeEditBox.h" />
     <ClInclude Include="OptimizeEditBox_Hook.h" />
     <ClInclude Include="pch.h" />

--- a/OptimizeEditBox/OptimizeEditBox_Hook.h
+++ b/OptimizeEditBox/OptimizeEditBox_Hook.h
@@ -32,7 +32,11 @@
 //---------------------------------------------------------------------
 // Api Hook
 
-DECLARE_HOOK_PROC(BOOL, WINAPI, GetMessageA, (LPMSG msg, HWND hwnd, UINT msgFilterMin, UINT msgFilterMax));
+//DECLARE_HOOK_PROC(BOOL, WINAPI, GetMessageA, (LPMSG msg, HWND hwnd, UINT msgFilterMin, UINT msgFilterMax));
+decltype(GetMessageA) hook_ctrlA_GetMessageA;
+extern decltype(&GetMessageA) true_GetMessageA, hook_GetMessageA;
+constexpr decltype(&DispatchMessageA) hook_DispatchMessageA = DispatchMessageW;
+extern decltype(&DispatchMessageA) true_DispatchMessageA;
 DECLARE_HOOK_PROC(BOOL, WINAPI, PeekMessageA, (LPMSG msg, HWND hwnd, UINT msgFilterMin, UINT msgFilterMax, UINT removeMsg));
 DECLARE_HOOK_PROC(HWND, WINAPI, CreateWindowExA, (DWORD exStyle, LPCSTR className, LPCSTR windowName, DWORD style, int x, int y, int w, int h, HWND parent, HMENU menu, HINSTANCE instance, LPVOID param));
 DECLARE_HOOK_PROC(void, CDECL, Exedit_FillGradation, (HDC dc, const RECT *rc, BYTE r, BYTE g, BYTE b, BYTE gr, BYTE gg, BYTE gb, int gs, int ge));

--- a/OptimizeEditBox/edit_predicates.h
+++ b/OptimizeEditBox/edit_predicates.h
@@ -13,7 +13,7 @@
 //	ID = id_edit_base + idx_filter * id_diff_per_filter + id_ofs_****
 // ID が他コントロールと重複することはあるが，それが原因で明確な誤動作をした経験はこのプラグインでは今のところない．
 inline bool editbox_check_id(uint32_t id) {
-	static constexpr uint32_t id_edit_base = 22100, id_diff_per_filter = 0x100,
+	constexpr uint32_t id_edit_base = 22100, id_diff_per_filter = 0x100,
 		id_ofs_text = 1, id_ofs_script = 0;
 	return id >= id_edit_base &&
 		(id - id_edit_base) % id_diff_per_filter <= std::max(id_ofs_text, id_ofs_script);
@@ -27,8 +27,7 @@ inline bool check_window_classname(HWND hwnd, const wchar_t(&name)[N])
 }
 // 対象エディットボックスのスタイル確認項目．
 // 複数行表示，Enterキーで改行可能，隠れていないという条件を満たすものとする．
-inline bool editbox_check_style(HWND hwnd)
-{
+inline bool editbox_check_style(HWND hwnd) {
 	constexpr auto
 		style = ES_MULTILINE | ES_WANTRETURN | WS_VISIBLE,
 		style_mask = style;

--- a/OptimizeEditBox/edit_predicates.h
+++ b/OptimizeEditBox/edit_predicates.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 
 #include <cstdint>
 #include <array>
@@ -8,25 +8,25 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-// ƒeƒLƒXƒgƒIƒuƒWƒFƒNƒgCƒXƒNƒŠƒvƒg§ŒäCƒJƒƒ‰ƒXƒNƒŠƒvƒg§Œä‚ÌƒGƒfƒBƒbƒgƒ{ƒbƒNƒX‚Í
-// “Á’è‚Ì ID ‚ÉŠ„‚èU‚ç‚ê‚é:
+// ãƒ†ã‚­ã‚¹ãƒˆã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆï¼Œã‚¹ã‚¯ãƒªãƒ—ãƒˆåˆ¶å¾¡ï¼Œã‚«ãƒ¡ãƒ©ã‚¹ã‚¯ãƒªãƒ—ãƒˆåˆ¶å¾¡ã®ã‚¨ãƒ‡ã‚£ãƒƒãƒˆãƒœãƒƒã‚¯ã‚¹ã¯
+// ç‰¹å®šã® ID ã«å‰²ã‚ŠæŒ¯ã‚‰ã‚Œã‚‹:
 //	ID = id_edit_base + idx_filter * id_diff_per_filter + id_ofs_****
-// ID ‚ª‘¼ƒRƒ“ƒgƒ[ƒ‹‚Æd•¡‚·‚é‚±‚Æ‚Í‚ ‚é‚ªC‚»‚ê‚ªŒ´ˆö‚Å–¾Šm‚ÈŒë“®ì‚ğ‚µ‚½ŒoŒ±‚Í‚±‚Ìƒvƒ‰ƒOƒCƒ“‚Å‚Í¡‚Ì‚Æ‚±‚ë‚È‚¢D
+// ID ãŒä»–ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ã¨é‡è¤‡ã™ã‚‹ã“ã¨ã¯ã‚ã‚‹ãŒï¼Œãã‚ŒãŒåŸå› ã§æ˜ç¢ºãªèª¤å‹•ä½œã‚’ã—ãŸçµŒé¨“ã¯ã“ã®ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã§ã¯ä»Šã®ã¨ã“ã‚ãªã„ï¼
 inline bool editbox_check_id(uint32_t id) {
 	static constexpr uint32_t id_edit_base = 22100, id_diff_per_filter = 0x100,
 		id_ofs_text = 1, id_ofs_script = 0;
 	return id >= id_edit_base &&
 		(id - id_edit_base) % id_diff_per_filter <= std::max(id_ofs_text, id_ofs_script);
 }
-// ƒEƒBƒ“ƒhƒEƒNƒ‰ƒX‚Ì–¼‘Oˆê’v‚ğŠm”F‚·‚éŠÖ”D–ˆ‰ñ MAX_PATH •¶š‚àŠm•Û‚µ‚È‚­‚Ä‚à‚æ‚¢D
+// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‚¯ãƒ©ã‚¹ã®åå‰ä¸€è‡´ã‚’ç¢ºèªã™ã‚‹é–¢æ•°ï¼æ¯å› MAX_PATH æ–‡å­—ã‚‚ç¢ºä¿ã—ãªãã¦ã‚‚ã‚ˆã„ï¼
 template<size_t N>
 inline bool check_window_classname(HWND hwnd, const wchar_t(&name)[N])
 {
 	wchar_t buff[N + 1];
 	return ::GetClassNameW(hwnd, buff, std::size(buff)) == N - 1 && std::wcscmp(buff, name) == 0;
 }
-// ‘ÎÛƒGƒfƒBƒbƒgƒ{ƒbƒNƒX‚ÌƒXƒ^ƒCƒ‹Šm”F€–ÚD
-// •¡”s•\¦CEnterƒL[‚Å‰üs‰Â”\C‰B‚ê‚Ä‚¢‚È‚¢‚Æ‚¢‚¤ğŒ‚ğ–‚½‚·‚à‚Ì‚Æ‚·‚éD
+// å¯¾è±¡ã‚¨ãƒ‡ã‚£ãƒƒãƒˆãƒœãƒƒã‚¯ã‚¹ã®ã‚¹ã‚¿ã‚¤ãƒ«ç¢ºèªé …ç›®ï¼
+// è¤‡æ•°è¡Œè¡¨ç¤ºï¼ŒEnterã‚­ãƒ¼ã§æ”¹è¡Œå¯èƒ½ï¼Œéš ã‚Œã¦ã„ãªã„ã¨ã„ã†æ¡ä»¶ã‚’æº€ãŸã™ã‚‚ã®ã¨ã™ã‚‹ï¼
 inline bool editbox_check_style(HWND hwnd)
 {
 	constexpr auto

--- a/OptimizeEditBox/edit_predicates.h
+++ b/OptimizeEditBox/edit_predicates.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstdint>
+#include <array>
+#include <cwchar>
+
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+// テキストオブジェクト，スクリプト制御，カメラスクリプト制御のエディットボックスは
+// 特定の ID に割り振られる:
+//	ID = id_edit_base + idx_filter * id_diff_per_filter + id_ofs_****
+// ID が他コントロールと重複することはあるが，それが原因で明確な誤動作をした経験はこのプラグインでは今のところない．
+inline bool editbox_check_id(uint32_t id) {
+	static constexpr uint32_t id_edit_base = 22100, id_diff_per_filter = 0x100,
+		id_ofs_text = 1, id_ofs_script = 0;
+	return id >= id_edit_base &&
+		(id - id_edit_base) % id_diff_per_filter <= std::max(id_ofs_text, id_ofs_script);
+}
+// ウィンドウクラスの名前一致を確認する関数．毎回 MAX_PATH 文字も確保しなくてもよい．
+template<size_t N>
+inline bool check_window_classname(HWND hwnd, const wchar_t(&name)[N])
+{
+	wchar_t buff[N + 1];
+	return ::GetClassNameW(hwnd, buff, std::size(buff)) == N - 1 && std::wcscmp(buff, name) == 0;
+}
+// 対象エディットボックスのスタイル確認項目．
+// 複数行表示，Enterキーで改行可能，隠れていないという条件を満たすものとする．
+inline bool editbox_check_style(HWND hwnd)
+{
+	constexpr auto
+		style = ES_MULTILINE | ES_WANTRETURN | WS_VISIBLE,
+		style_mask = style;
+	return (::GetWindowLongW(hwnd, GWL_STYLE) & style_mask) == style;
+}


### PR DESCRIPTION
1. エディットボックスでESCでダイアログが閉じてしまったのを修正．
1. エディットボックスの高さ変更を指定しないとフォント変更が反映されなかったのを修正．
1. エディットボックスのサブクラス化を用事が済んだら解除．

自前の改造版から本家にポートできる部分です．ESC でダイアログが閉じてしまっていた原因は不明ですが，メッセージを破棄することで起こらなくなりました．ご確認していただければと思います．